### PR TITLE
fix: stop repeated browser auth popups on token expiry

### DIFF
--- a/src/utils/apisHandler.ts
+++ b/src/utils/apisHandler.ts
@@ -78,6 +78,12 @@ async function redirectToGoogle(
     "https://www.googleapis.com/auth/tagmanager.publish",
     "https://www.googleapis.com/auth/tagmanager.readonly",
   ];
+
+  // Check if the user explicitly wants to force consent (e.g. to obtain a new refresh token)
+  const forceConsent =
+    c.req.query("force_consent") === "true" ||
+    c.req.query("prompt") === "consent";
+
   return new Response(null, {
     status: 302,
     headers: {
@@ -89,7 +95,7 @@ async function redirectToGoogle(
         redirectUri: new URL("/callback", c.req.raw.url).href,
         state: btoa(JSON.stringify(oauthReqInfo)),
         hostedDomain: c.env.HOSTED_DOMAIN,
-        hasRefreshToken: false,
+        hasRefreshToken: !forceConsent,
       }),
     },
   });

--- a/src/utils/authorizeUtils.ts
+++ b/src/utils/authorizeUtils.ts
@@ -175,8 +175,11 @@ export async function handleTokenExchangeCallback(
   const now = Math.floor(Date.now() / 1000);
 
   if (grantType === "authorization_code") {
-    // Regular TTL for the MCP access token
-    return { accessTokenTTL: 1800 };
+    // TTL for the MCP access token (7 days).
+    // The upstream Google token is refreshed automatically via the
+    // refresh_token grant, so a long-lived MCP token is safe and avoids
+    // frequent re-authentication browser pop-ups.
+    return { accessTokenTTL: 604800 };
   }
 
   if (grantType === "refresh_token") {
@@ -189,7 +192,7 @@ export async function handleTokenExchangeCallback(
     // Heartbeat: If token expires in less than 15 minutes, refresh it.
     const REFRESH_THRESHOLD = 900;
     if (expiresAt >= now + REFRESH_THRESHOLD) {
-      return { accessTokenTTL: 1800 };
+      return { accessTokenTTL: 604800 };
     }
 
     const [token, err] = await refreshUpstreamAuthToken({
@@ -210,7 +213,7 @@ export async function handleTokenExchangeCallback(
         expiresAt: now + token.expires_in,
         refreshToken: token.refresh_token || p.refreshToken,
       } satisfies Props,
-      accessTokenTTL: 1800,
+      accessTokenTTL: 604800,
     };
   }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where each MCP client connection (or token refresh) opens a new Google OAuth consent tab in the browser. This is especially disruptive when running multiple clients simultaneously (e.g. 5 Cursor containers each triggering their own auth flow).

**Root causes:**

1. **`hasRefreshToken: false` hardcoded** in `redirectToGoogle()` — this sets `prompt=consent` on every Google OAuth redirect, forcing the consent screen to appear even for already-authenticated users. Google only needs to show the consent screen once per user; on subsequent authorizations it can auto-redirect silently.

2. **`accessTokenTTL: 1800` (30 min) is too short** — when the MCP access token expires and the refresh flow fails for any reason, the client falls back to a full re-authorization, opening another browser tab. A longer TTL reduces refresh frequency and the chance of hitting this fallback.

## Changes

- **`apisHandler.ts`**: Replace hardcoded `hasRefreshToken: false` with dynamic check. Default behavior no longer forces `prompt=consent`. A `force_consent=true` query parameter is available as an escape hatch when a new refresh token is explicitly needed.

- **`authorizeUtils.ts`**: Increase `accessTokenTTL` from `1800` (30 min) to `604800` (7 days) for all grant types. The upstream Google access token is still refreshed automatically via the `refresh_token` grant in `handleTokenExchangeCallback`, so a long-lived MCP token is safe.

## Test plan

- [ ] First-time auth: user should see Google consent screen once and get both access_token and refresh_token
- [ ] Subsequent auth (new client, same user): should auto-redirect through Google without showing consent screen
- [ ] Token refresh after Google token expiry: should refresh silently without opening a browser
- [ ] Multiple simultaneous clients: should not trigger multiple consent tabs
- [ ] `?force_consent=true` on `/authorize`: should force the consent screen (escape hatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)