### PR TITLE
Fix variable update dropping formatValue/parentFolderId and other fields

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,5 @@
+GOOGLE_CLIENT_ID="your-oauth-client-id.apps.googleusercontent.com"
+GOOGLE_CLIENT_SECRET="your-oauth-client-secret"
+COOKIE_ENCRYPTION_KEY="use-a-random-secret-key-at-least-32-chars"
+WORKER_HOST="http://localhost:8788"
+HOSTED_DOMAIN=""

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ To avoid this issue:
 **Clearing MCP Cache**
 
 [mcp-remote](https://github.com/geelen/mcp-remote#readme) stores all the credential information inside `~/.mcp-auth` (or wherever your `MCP_REMOTE_CONFIG_DIR` points to). If you're having persistent issues, try running:
-You can run:
 ```bash
 rm -rf ~/.mcp-auth
 ```

--- a/README.md
+++ b/README.md
@@ -36,9 +36,73 @@ To avoid this issue:
 
 **Clearing MCP Cache**
 
-[mcp-remote](https://github.com/geelen/mcp-remote#readme) stores all the credential information inside ~/.mcp-auth (or wherever your MCP_REMOTE_CONFIG_DIR points to). If you're having persistent issues, try running:
-You can run rm -rf ~/.mcp-auth to clear any locally stored state and tokens.
-```
+[mcp-remote](https://github.com/geelen/mcp-remote#readme) stores all the credential information inside `~/.mcp-auth` (or wherever your `MCP_REMOTE_CONFIG_DIR` points to). If you're having persistent issues, try running:
+You can run:
+```bash
 rm -rf ~/.mcp-auth
 ```
-Then restarting your MCP client.
+Then, restart your MCP client.
+
+## Running locally for development/testing
+
+You can run the server on your own machine against your own Google Cloud OAuth
+credentials instead of the hosted `gtm-mcp.stape.ai` server. This is useful for testing
+changes before they're deployed.
+
+### 1. Set up a Google Cloud OAuth client
+
+1. In the [Google Cloud Console](https://console.cloud.google.com/), create or select a project, then enable the **Tag Manager API**.
+2. Go to **APIs & Services > OAuth consent screen** and configure it (External is fine). While the app is in **Testing** publishing status, only accounts listed as test users can log in.
+3. Go to **Audience**, under **Test users** add your own Google account.
+4. Go to **APIs & Services > Credentials > Create Credentials > OAuth client ID**, type **Web application**.
+5. Under **Authorized redirect URIs**, add `http://localhost:8788/callback`. (You can leave **Authorized JavaScript origins** empty — this flow is server-side only, no browser JS calls Google directly.)
+6. Save, then copy the generated **Client ID** and **Client secret**.
+
+### 2. Configure local environment variables
+
+Copy the example file and fill in the values from the previous step:
+
+```bash
+cp .dev.vars.example .dev.vars
+```
+
+```
+GOOGLE_CLIENT_ID="<your client ID>"
+GOOGLE_CLIENT_SECRET="<your client secret>"
+COOKIE_ENCRYPTION_KEY="<any random string, at least 32 chars, e.g. output of: openssl rand -hex 32>"
+WORKER_HOST="http://localhost:8788"
+HOSTED_DOMAIN=""
+```
+
+`.dev.vars` is git-ignored — it's only used locally and never committed.
+
+### 3. Start the server
+
+```bash
+npm install
+npm run dev
+```
+
+This starts the Worker on `http://localhost:8788`.
+
+### 4. Point your MCP client at the local server
+
+Same as the [Claude Desktop config above](#access-the-remote-mcp-server-from-claude-desktop), but pointing at `localhost` instead of the hosted URL:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server-local": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "http://localhost:8788/mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. A browser window will open for the Google OAuth flow; log in with the
+account you added as a test user in step 1.
+
+**Note:** if you've previously connected to the hosted server (or switch back and forth between
+local and hosted), clear mcp-remote's cache first (see "Clearing MCP Cache" above)
+and fully restart your MCP client, otherwise it may reuse a stale/cached connection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,7 +1458,6 @@
       "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1511,7 +1510,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.30.1.tgz",
       "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.1",
         "@typescript-eslint/types": "8.30.1",
@@ -1705,7 +1703,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2419,7 +2416,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.24.0.tgz",
       "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2480,7 +2476,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
       "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2695,7 +2690,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -4057,7 +4051,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4658,7 +4651,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4844,7 +4836,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4908,7 +4899,6 @@
       "integrity": "sha512-B06u0wXkEd+o5gOCMl/ZHl5cfpYbDZKAT+HWTL+Hws6jWu7dCiqBBXXXzMFcFVJb8D4ytAnYmxJA83uwOQRSsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.4",
@@ -5016,7 +5006,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -5150,7 +5139,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "lint:fix": "eslint --ext .ts src --fix",
     "prepublish": "npm run build",
     "deploy": "wrangler deploy",
-    "dev": "wrangler dev",
-    "start": "wrangler dev",
+    "dev": "wrangler dev --local-upstream localhost:8788",
+    "start": "wrangler dev --local-upstream localhost:8788",
     "cf-typegen": "wrangler types --include-env=false"
   },
   "dependencies": {

--- a/src/schemas/VariableSchema.ts
+++ b/src/schemas/VariableSchema.ts
@@ -77,7 +77,7 @@ export const VariableSchema = z.object({
     .array(z.string())
     .optional()
     .describe(
-      "For mobile containers only: A list of trigger IDs for disabling conditional variables; the variable is enabled if one of the enabling trigger is true while all the disabling trigger are false. Treated as an unordered set.",
+      "For mobile containers only: A list of trigger IDs for disabling conditional variables; the variable is enabled if one of the enabling triggers is true while all the disabling triggers are false. Treated as an unordered set.",
     ),
   scheduleStartMs: z
     .string()

--- a/src/schemas/VariableSchema.ts
+++ b/src/schemas/VariableSchema.ts
@@ -7,6 +7,38 @@ export const CaseConversionTypeEnum = z.enum([
   "uppercase",
 ]);
 
+export const DecimalSeparatorTypeEnum = z.enum([
+  "decimalSeparatorTypeUnspecified",
+  "period",
+  "comma",
+  "automatic",
+]);
+
+const VariableFormatValueSchema = z.object({
+  caseConversionType: CaseConversionTypeEnum.optional().describe(
+    "The option to convert a string-type variable value to either lowercase or uppercase.",
+  ),
+  convertToNumber: DecimalSeparatorTypeEnum.optional().describe(
+    "The option to convert a variable value to a number.",
+  ),
+  convertNullToValue: ParameterSchema.optional().describe(
+    "The value to convert if a variable value is null.",
+  ),
+  convertUndefinedToValue: ParameterSchema.optional().describe(
+    "The value to convert if a variable value is undefined.",
+  ),
+  convertToBoolean: z
+    .boolean()
+    .optional()
+    .describe("The option to convert a variable value to a boolean."),
+  convertTrueToValue: ParameterSchema.optional().describe(
+    "The value to convert if a variable value is true.",
+  ),
+  convertFalseToValue: ParameterSchema.optional().describe(
+    "The value to convert if a variable value is false.",
+  ),
+});
+
 export const VariableSchema = z.object({
   accountId: z.string().describe("GTM Account ID."),
   containerId: z.string().describe("GTM Container ID."),
@@ -31,6 +63,30 @@ export const VariableSchema = z.object({
     .string()
     .optional()
     .describe("User notes on how to apply this variable in the container."),
+  formatValue: VariableFormatValueSchema.optional().describe(
+    "Option to convert a variable value to other value.",
+  ),
+  parentFolderId: z.string().optional().describe("Parent folder id."),
+  enablingTriggerId: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "For mobile containers only: A list of trigger IDs for enabling conditional variables; the variable is enabled if one of the enabling triggers is true while all the disabling triggers are false. Treated as an unordered set.",
+    ),
+  disablingTriggerId: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "For mobile containers only: A list of trigger IDs for disabling conditional variables; the variable is enabled if one of the enabling trigger is true while all the disabling trigger are false. Treated as an unordered set.",
+    ),
+  scheduleStartMs: z
+    .string()
+    .optional()
+    .describe("The start timestamp in milliseconds to schedule a variable."),
+  scheduleEndMs: z
+    .string()
+    .optional()
+    .describe("The end timestamp in milliseconds to schedule a variable."),
   tagManagerUrl: z
     .string()
     .optional()

--- a/src/schemas/VariableSchema.ts
+++ b/src/schemas/VariableSchema.ts
@@ -64,7 +64,7 @@ export const VariableSchema = z.object({
     .optional()
     .describe("User notes on how to apply this variable in the container."),
   formatValue: VariableFormatValueSchema.optional().describe(
-    "Option to convert a variable value to other value.",
+    "Options to convert a variable value to another value.",
   ),
   parentFolderId: z.string().optional().describe("Parent folder id."),
   enablingTriggerId: z

--- a/src/tools/variableActions.ts
+++ b/src/tools/variableActions.ts
@@ -54,7 +54,7 @@ export const variableActions = (
           "The unique ID of the GTM variable. Required for 'get', 'update', 'remove', and 'revert' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM variable resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM variable resource, except IDs. 'update' replaces the entire variable — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()


### PR DESCRIPTION
VariableSchema only modeled name/type/parameter/notes, so the GTM API's Variable resource fields (formatValue, parentFolderId, enablingTriggerId, disablingTriggerId, scheduleStartMs, scheduleEndMs) had no way to round-trip through 'update', causing them to be silently deleted on every full-PUT update (client-side safety checks correctly flagged this as unsafe).

Fixes the problem that causes the following message to appear in the AI Agent:
> "Unsafe update: the get response for this variable contains formatValue, which does not exist in the gtm_variable createOrUpdateConfig schema. Since update performs a full PUT without merging with the current entity, this field would be silently deleted. Skipping this variable."


- Add VariableFormatValueSchema (caseConversionType, convertToNumber, convertNullToValue, convertUndefinedToValue, convertToBoolean, convertTrueToValue, convertFalseToValue), matching the live GTM API Variable.FormatValue resource (verified against the tagmanager v2 discovery document, not just the bundled googleapis npm typings which were stale).
- Add the 6 missing top-level Variable fields.
- Document in the tool description that 'update' is a full replace, so callers should 'get' first and send back the complete object.
- Add npm run dev/start --local-upstream flag so local wrangler dev doesn't simulate the production custom-domain route (which broke local OAuth discovery), with no manual wrangler.jsonc edits required.
- Add .dev.vars.example and a README section documenting local setup: GCP OAuth client creation, test user allowlisting, redirect URI, and connecting an MCP client to the local server.