### PR TITLE
Add a manual trigger to Release, and skip the changeset check on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
   changeset:
     runs-on: ubuntu-latest
+    # The release pull request consumes changesets, so it never carries one.
+    if: github.head_ref != 'changeset-release/main'
     # Advisory: not every pull request needs a changeset. Drop this to enforce.
     continue-on-error: true
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: main
+  workflow_dispatch:
 
 concurrency: release-${{ github.ref }}
 


### PR DESCRIPTION
Two things the first release surfaced.

**`Release` had no manual trigger.** It ran only on `push: branches: main`, so when [run 32011738642](https://github.com/stape-io/google-tag-manager-mcp-server/actions/runs/32011738642) failed on the org's "actions user cannot create pull requests" restriction, there was no button to re-run it after the fix — it took another push to main. `workflow_dispatch` gives it one.

**The advisory changeset check fails on every release PR.** It looks for packages that changed without a changeset, which `chore: version packages` can never satisfy — that PR is what consumes them. Job-level `continue-on-error` keeps the workflow run green but still reports the job as failed, so #65 shows a red check that means nothing. It is now skipped on the `changeset-release/main` branch and keeps working everywhere else.

Merging this rebases the release PR onto a main that has the fix, so its checks come back green and #65 can be merged to publish.