### PR TITLE
Deploy the Worker only when something it is built from changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,15 @@ name: Deploy
 on:
   push:
     branches: main
+    # Everything the Worker bundle is built from. A path missing here means the
+    # Worker silently keeps serving the previous build.
+    paths:
+      - "apps/worker/**"
+      - "packages/core/**"
+      - "scripts/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/deploy.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Every merge to `main` redeploys the Worker, including merges that cannot affect it — the `chore: version packages` merge that just shipped 4.0.0 triggered one, and so did the workflow-only change before it.

It is not harmful, but each redeploy adds another identical bundle to the Cloudflare deployment list, which is the list you have to pick a target out of when rolling back.

The trigger now filters on the paths the Worker bundle is actually built from:

```yaml
paths:
  - "apps/worker/**"
  - "packages/core/**"      # the Worker bundles core
  - "scripts/**"            # generate-version runs during its build
  - "package.json"
  - "package-lock.json"
  - ".github/workflows/deploy.yml"
```

`workflow_dispatch` stays, so a deploy can still be forced by hand at any time.

The one thing to keep in mind: "main is deployed" is no longer strictly true. A path missing from that list means the Worker silently keeps serving the previous build, so a new workspace that the Worker imports has to be added here too — there is a comment in the file saying exactly that.