### PR TITLE
Tear the SSE keepalive down when the client goes away

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -116,7 +116,13 @@ export default {
         path: url.pathname,
       });
 
-      if (response.status >= 400) {
+      // Every client opens with an unauthenticated probe to discover where to
+      // authorize, so a 401 here is the protocol working. Logging it as an
+      // error buries the failures worth finding.
+      const isAuthChallenge =
+        response.status === 401 && (isMcp || url.pathname === "/mcp");
+
+      if (response.status >= 400 && !isAuthChallenge) {
         console.error("[HTTP] Error response", {
           requestId,
           status: response.status,
@@ -126,7 +132,7 @@ export default {
       }
 
       if (isMcp || isLegacySse) {
-        return withSseKeepalive(response);
+        return withSseKeepalive(response, request.signal);
       }
 
       return response;

--- a/apps/worker/src/utils/sseKeepalive.ts
+++ b/apps/worker/src/utils/sseKeepalive.ts
@@ -7,7 +7,10 @@ const KEEPALIVE_FRAME = ": keepalive\n\n";
  * `agents` heartbeats only the per-request POST stream, so the long-lived GET
  * stream a client listens on would otherwise sit silent until it is dropped.
  */
-export function withSseKeepalive(response: Response): Response {
+export function withSseKeepalive(
+  response: Response,
+  signal: AbortSignal,
+): Response {
   const body = response.body;
   const isEventStream = response.headers
     .get("content-type")
@@ -19,6 +22,7 @@ export function withSseKeepalive(response: Response): Response {
 
   const { readable, writable } = new TransformStream();
   const writer = writable.getWriter();
+  const reader = body.getReader();
   const encoder = new TextEncoder();
 
   // Upstream may split one event across chunks; a frame injected mid-event
@@ -35,9 +39,20 @@ export function withSseKeepalive(response: Response): Response {
     });
   }, KEEPALIVE_INTERVAL_MS);
 
-  void (async (): Promise<void> => {
-    const reader = body.getReader();
+  // A client that drops the stream leaves the timer running until a write
+  // happens to fail, and `reader.read()` parked forever. The runtime counts
+  // both against the invocation and eventually kills them, which is what
+  // "waitUntil() tasks did not complete" in the logs means. Reconnect storms
+  // pile these up, so tear down on the request signal rather than on the next
+  // failed write.
+  const teardown = (): void => {
+    clearInterval(timer);
+    void reader.cancel().catch(() => {});
+  };
 
+  signal.addEventListener("abort", teardown, { once: true });
+
+  void (async (): Promise<void> => {
     try {
       for (;;) {
         const { done, value } = await reader.read();
@@ -57,6 +72,7 @@ export function withSseKeepalive(response: Response): Response {
       // Upstream aborted.
     } finally {
       clearInterval(timer);
+      signal.removeEventListener("abort", teardown);
       await writer.close().catch(() => {});
     }
   })();


### PR DESCRIPTION
Follow-up to #69, which introduced the keepalive. Production logs show it leaving work behind.

## What the logs showed

A one-minute sample from the Worker carried 17 `waitUntil() tasks did not complete within the allowed time` warnings. **15 of them were on `GET /mcp`** — the path the keepalive wraps. The MCP transport in `agents` calls `waitUntil` nowhere, so the background work is ours.

The mechanism: the interval only stopped once a write happened to fail, and `reader.read()` on the upstream body stayed parked indefinitely. A client that dropped its stream left both alive until the runtime gave up on them. With clients reconnecting rapidly, these accumulate.

Note `waitUntil()` is not the fix here — the stream is meant to live for minutes, well past what that budget allows. The problem is teardown, not registration.

## The change

Both the interval and the upstream read now tear down on the request's abort signal, as soon as the client is gone, rather than waiting for the next failed write.

Also stopped logging the unauthenticated probe as an error. Every client opens with one to discover where to authorize, so a `401` on `/mcp` is the protocol working — it accounted for 23 of the 29 error-level lines in the same sample and buried everything else. Real `4xx`/`5xx` still log as errors.

## Verification

Against a local harness running the real `McpAgent` on a Durable Object behind the real OAuth provider:

- Keepalive still fires — 3 frames over 80s at intervals of `[25.0, 25.0]`
- Full session unaffected — `initialize` 200, `notifications/initialized` 202, `tools/list` 200
- Storm test — 8 streams opened and abruptly aborted, after which a fresh session still completes and the Worker log carries no errors

`typecheck` 0, `build` 0, `lint` 0 errors.

## What this does not fix

The disconnects that motivated #69 have a client-side cause: on accounts with Cowork, Claude runs a second, independent copy of the MCP client and authorizes twice, opening the auth window twice. Fresh accounts behave.

That matches the sample: 21 distinct MCP sessions in 64 seconds across five user agents (`Claude-User`, `claude-code/2.1.238 (cli)`, `claude-code/2.1.198 (sdk-ts, agent-sdk)`, `node`, `undici`), 12 token exchanges and 4 authorization redirects in that minute. Clients sharing a grant refresh concurrently, and the provider rotates the refresh token keeping only current and previous, so the third concurrent refresh presents a token two generations old and gets `invalid_grant` — the provider's own, already correct, error. It is raised before `tokenExchangeCallback` runs, which is why the handler added in #69 never fired: zero occurrences of its log line in the sample.

Nothing in this repository causes that, and no server-side change here resolves it.
