### PR TITLE
Fix gtm_destination empty-response crash and rename to gtag_destination

### DIFF
--- a/.changeset/tame-eagles-jump.md
+++ b/.changeset/tame-eagles-jump.md
@@ -1,0 +1,6 @@
+---
+"google-tag-manager-mcp-core": minor
+"google-tag-manager-mcp-server": minor
+---
+
+Fix `gtm_destination` crashing with `allItems.slice is not a function` when the Google API returns an empty object for a container with no linked Google Tags, and rename the tool to `gtag_destination` to reflect that it manages Google Tags (tagmanager.google.com/#/home#tags), not classic GTM container destinations. Also removed the `get`, `link`, and `unlink` actions: `get`/`link` are deprecated by Google and `unlink` was never part of the API; `list` is now the only supported action.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -62,7 +62,7 @@ Optionally, `GTM_SCOPES` overrides the requested scopes (space or comma separate
 
 One tool per GTM resource, each taking an `action` parameter (`list`, `get`, `create`, `update`, `remove`, …):
 
-`gtm_account`, `gtm_container`, `gtm_workspace`, `gtm_tag`, `gtm_trigger`, `gtm_variable`, `gtm_built_in_variable`, `gtm_folder`, `gtm_client`, `gtm_template`, `gtm_transformation`, `gtm_zone`, `gtm_environment`, `gtm_version`, `gtm_version_header`, `gtm_gtag_config`, `gtm_destination`, `gtm_user_permission`.
+`gtm_account`, `gtm_container`, `gtm_workspace`, `gtm_tag`, `gtm_trigger`, `gtm_variable`, `gtm_built_in_variable`, `gtm_folder`, `gtm_client`, `gtm_template`, `gtm_transformation`, `gtm_zone`, `gtm_environment`, `gtm_version`, `gtm_version_header`, `gtm_gtag_config`, `gtag_destination`, `gtm_user_permission`.
 
 The tools themselves live in [`google-tag-manager-mcp-core`](https://www.npmjs.com/package/google-tag-manager-mcp-core), which you can reuse to build a server with your own authentication.
 

--- a/packages/core/src/tools/destinationActions.ts
+++ b/packages/core/src/tools/destinationActions.ts
@@ -1,14 +1,12 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { tagmanager_v2 } from "@googleapis/tagmanager";
-import { z } from "zod";
-import { GtmToolContext } from "../types/index.js";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { GtmToolContext } from '../types/index.js';
 import {
   createErrorResponse,
   getTagManagerClient,
   log,
   paginateArray,
-} from "../utils/index.js";
-import Schema$Destination = tagmanager_v2.Schema$Destination;
+} from '../utils/index.js';
 
 const ITEMS_PER_PAGE = 50;
 
@@ -17,35 +15,18 @@ export const destinationActions = (
   { auth }: GtmToolContext,
 ): void => {
   server.tool(
-    "gtm_destination",
-    `Performs all destination operations: get, list, link, unlink.  The 'list' action returns up to ${ITEMS_PER_PAGE} items per page.`,
+    'gtag_destination',
+    `Lists the Google Tag destinations listed under https://tagmanager.google.com/#/home#tags. This is not the classic GTM "destination" concept from the tagmanager.google.com UI; passing a regular GTM Container ID here typically returns no results. It only returns data for Google Tag IDs, i.e. the tags listed under tagmanager.google.com/#/home#tags. Returns up to ${ITEMS_PER_PAGE} items per page. Note: this is the only action the underlying Google API still supports; 'get' and 'link' are deprecated by Google.e`,
     {
-      action: z
-        .enum(["get", "list", "link", "unlink"])
-        .describe(
-          "The destination operation to perform. Must be one of: 'get', 'list', 'link', 'unlink'.",
-        ),
       accountId: z
         .string()
         .describe(
-          "The unique ID of the GTM Account containing the destination.",
+          'The unique ID of the GTM Account containing the destination.',
         ),
       containerId: z
         .string()
         .describe(
-          "The unique ID of the GTM Container containing the destination.",
-        ),
-      destinationId: z
-        .string()
-        .optional()
-        .describe(
-          "The unique ID of the GTM Destination. Required for 'get', 'link', and 'unlink' actions.",
-        ),
-      allowUserPermissionFeatureUpdate: z
-        .boolean()
-        .optional()
-        .describe(
-          "If true, allows user permission feature update during linking. Optional for 'link' action.",
+          'The unique ID of the GTM Container (or Google Tag) containing the destination.',
         ),
       page: z
         .number()
@@ -63,105 +44,31 @@ export const destinationActions = (
           `Number of items to return per page (1-${ITEMS_PER_PAGE}). Default: ${ITEMS_PER_PAGE}. Use lower values if experiencing response issues.`,
         ),
     },
-    async ({
-      action,
-      accountId,
-      containerId,
-      destinationId,
-      allowUserPermissionFeatureUpdate,
-      page,
-      itemsPerPage,
-    }) => {
-      log(`Running tool: gtm_destination with action ${action}`);
+    async ({ accountId, containerId, page, itemsPerPage }) => {
+      log(`Running tool: gtm_gtag_destination with action list`);
 
       try {
         const tagmanager = await getTagManagerClient(auth);
 
-        switch (action) {
-          case "get": {
-            if (!destinationId) {
-              throw new Error(`destinationId is required for ${action} action`);
-            }
+        const response = await tagmanager.accounts.containers.destinations.list(
+          {
+            parent: `accounts/${accountId}/containers/${containerId}`,
+          },
+        );
 
-            const response =
-              await tagmanager.accounts.containers.destinations.get({
-                path: `accounts/${accountId}/containers/${containerId}/destinations/${destinationId}`,
-              });
+        // ponytail: the API returns `{}` (no `destination` key) when there are no results,
+        // instead of `{ destination: [] }`.
+        const all = response.data.destination ?? [];
+        const paginatedResult = paginateArray(all, page, itemsPerPage);
 
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(response.data, null, 2) },
-              ],
-            };
-          }
-          case "list": {
-            const response =
-              await tagmanager.accounts.containers.destinations.list({
-                parent: `accounts/${accountId}/containers/${containerId}`,
-              });
-
-            const all = response.data as Schema$Destination[];
-            const paginatedResult = paginateArray(all, page, itemsPerPage);
-
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(paginatedResult, null, 2),
-                },
-              ],
-            };
-          }
-          case "link": {
-            if (!destinationId) {
-              throw new Error(`destinationId is required for ${action} action`);
-            }
-
-            const response =
-              await tagmanager.accounts.containers.destinations.link({
-                parent: `accounts/${accountId}/containers/${containerId}`,
-                destinationId,
-                allowUserPermissionFeatureUpdate,
-              });
-
-            return {
-              content: [
-                { type: "text", text: JSON.stringify(response.data, null, 2) },
-              ],
-            };
-          }
-          case "unlink": {
-            if (!destinationId) {
-              throw new Error(`destinationId is required for ${action} action`);
-            }
-
-            await tagmanager.accounts.containers.destinations.link({
-              parent: `accounts/${accountId}/containers/${containerId}`,
-              destinationId: destinationId,
-            });
-
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: JSON.stringify(
-                    {
-                      success: true,
-                      message: `Destination ${destinationId} was successfully unlinked`,
-                    },
-                    null,
-                    2,
-                  ),
-                },
-              ],
-            };
-          }
-          default:
-            throw new Error(`Unknown action: ${action}`);
-        }
+        return {
+          content: [
+            { type: 'text', text: JSON.stringify(paginatedResult, null, 2) },
+          ],
+        };
       } catch (error) {
         return createErrorResponse(
-          `Error performing ${action} on destination`,
+          'Error performing list on destination',
           error,
         );
       }

--- a/packages/core/src/tools/destinationActions.ts
+++ b/packages/core/src/tools/destinationActions.ts
@@ -1,12 +1,12 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import { GtmToolContext } from '../types/index.js';
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { GtmToolContext } from "../types/index.js";
 import {
   createErrorResponse,
   getTagManagerClient,
   log,
   paginateArray,
-} from '../utils/index.js';
+} from "../utils/index.js";
 
 const ITEMS_PER_PAGE = 50;
 
@@ -15,18 +15,18 @@ export const destinationActions = (
   { auth }: GtmToolContext,
 ): void => {
   server.tool(
-    'gtag_destination',
-    `Lists the Google Tag destinations listed under https://tagmanager.google.com/#/home#tags. This is not the classic GTM "destination" concept from the tagmanager.google.com UI; passing a regular GTM Container ID here typically returns no results. It only returns data for Google Tag IDs, i.e. the tags listed under tagmanager.google.com/#/home#tags. Returns up to ${ITEMS_PER_PAGE} items per page. Note: this is the only action the underlying Google API still supports; 'get' and 'link' are deprecated by Google.e`,
+    "gtag_destination",
+    `Lists the Google Tag destinations listed under https://tagmanager.google.com/#/home#tags. This is not the classic GTM "destination" concept from the tagmanager.google.com UI; passing a regular GTM Container ID here typically returns no results. It only returns data for Google Tag IDs, i.e. the tags listed under tagmanager.google.com/#/home#tags. Returns up to ${ITEMS_PER_PAGE} items per page. Note: this is the only action the underlying Google API still supports; 'get' and 'link' are deprecated by Google, and 'unlink' was never part of the API.`,
     {
       accountId: z
         .string()
         .describe(
-          'The unique ID of the GTM Account containing the destination.',
+          "The unique ID of the GTM Account containing the destination.",
         ),
       containerId: z
         .string()
         .describe(
-          'The unique ID of the GTM Container (or Google Tag) containing the destination.',
+          "The unique ID of the GTM Container (or Google Tag) containing the destination.",
         ),
       page: z
         .number()
@@ -45,7 +45,7 @@ export const destinationActions = (
         ),
     },
     async ({ accountId, containerId, page, itemsPerPage }) => {
-      log(`Running tool: gtm_gtag_destination with action list`);
+      log(`Running tool: gtag_destination with action list`);
 
       try {
         const tagmanager = await getTagManagerClient(auth);
@@ -63,12 +63,12 @@ export const destinationActions = (
 
         return {
           content: [
-            { type: 'text', text: JSON.stringify(paginatedResult, null, 2) },
+            { type: "text", text: JSON.stringify(paginatedResult, null, 2) },
           ],
         };
       } catch (error) {
         return createErrorResponse(
-          'Error performing list on destination',
+          "Error performing list on destination",
           error,
         );
       }


### PR DESCRIPTION
## Summary
- `accounts.containers.destinations.list` returns `{}` (no `destination` key) instead of `{ destination: [] }` when there are no results. This caused `allItems.slice is not a function`. Now defaults to `[]` before pagination.
- Removed the `get`, `link`, and `unlink` actions. `get`/`link` are marked deprecated by Google ("no longer supported and will soon be removed"), and `unlink` was never part of the Google Tag Manager API. `list` is the only action still supported.
- Renamed the tool from `gtm_destination` to gtag_destination` and rewrote its description: this endpoint manages **Google Tag** destinations (listed at tagmanager.google.com/#/home#tags), not classic GTM container destinations, despite what the Google API docs imply.

## References
- https://developers.google.com/tag-platform/tag-manager/api/reference/rest/v2/accounts.containers.destinations/list
- https://developers.google.com/tag-platform/tag-manager/api/reference/rest/v2/accounts.containers.destinations/get (deprecation warning)

Fixes #72