### PR TITLE
Fix empty Google API error message on write failures

### DIFF
--- a/.changeset/quiet-crews-clap.md
+++ b/.changeset/quiet-crews-clap.md
@@ -1,0 +1,6 @@
+---
+"google-tag-manager-mcp-core": patch
+"google-tag-manager-mcp-server": patch
+---
+
+Fix write actions (create/update/delete) returning an empty `Google API Error <code> -` message instead of Google's actual error detail. The shared error formatter only read the legacy `error.errors[]` field from the old Google API client, which modern `@googleapis/tagmanager` errors don't populate; it now falls back to `error.message` so the real cause is surfaced.

--- a/packages/core/src/utils/createErrorResponse.ts
+++ b/packages/core/src/utils/createErrorResponse.ts
@@ -21,11 +21,15 @@ export function createErrorResponse(
     if (error.code === 401) {
       detailedMessage = unauthorizedHint;
     } else {
-      const messages = (error?.errors || []).map(
-        (item: { message?: string }) => item?.message,
-      );
+      const legacyMessages = (error?.errors || [])
+        .map((item: { message?: string }) => item?.message)
+        .filter(Boolean);
 
-      detailedMessage = `${message}: Google API Error ${error.code} - ${messages.join(". ")}`;
+      const detail = legacyMessages.length
+        ? legacyMessages.join(". ")
+        : error?.message || "Unknown error";
+
+      detailedMessage = `${message}: Google API Error ${error.code} - ${detail}`;
     }
   } else if (error instanceof Error) {
     detailedMessage = `${message}: ${error.message}`;


### PR DESCRIPTION
## Summary

- `createErrorResponse` (shared by every write action: create/update/delete across all 18 GTM tools) only read the legacy `error.errors[]` array, a field from the old `googleapis` client's error shape.
- `@googleapis/tagmanager` v16 is built on `gaxios` 7, whose `GaxiosError` puts the real error text on `error.message` instead and doesn't populate `.errors`. That dependency was swapped in from `googleapis@128` (gaxios 6) in #63's refactor, which is when this started actually manifesting in production (v3.0.6).
- Result: every failed write returned `Google API Error 400 -` with an empty body, making failures undiagnosable — reported in #77.
- Fix: fall back to `error.message` when `error.errors` is empty/missing, while still honoring the legacy `errors[]` shape if present.

## Test plan

Verified end-to-end against a real GTM account/container via a local build of `packages/cli` (`GOOGLE_ACCESS_TOKEN` auth):
- [x] Repro of the original empty-400 bug confirmed against the currently deployed hosted server (via a peer session), before the fix.
- [x] After the fix, an invalid `gtm_trigger create` (missing `customEventFilter` for a `CUSTOM_EVENT` trigger) now returns `Google API Error 400 - customEventFilter: Custom-event trigger must have exactly one custom-event filter.` instead of an empty message.
- [x] A valid `gtm_trigger create` still succeeds and returns the full trigger object; cleaned up afterward.
- [x] An invalid `gtm_tag update` (name-only payload) now returns `Google API Error 400 - vendorTemplate.key: Unknown entity type (template public ID: ).` instead of an empty message; cleaned up afterward.
- [x] `npm run typecheck` / `npm run build` pass after fixing a stale local `node_modules/zod` (3.x vs the lockfile's 4.4.3 — unrelated to this change).
- [x] Changeset added (`google-tag-manager-mcp-core` + `google-tag-manager-mcp-server`, patch).

Fixes #77
