### PR TITLE
Warn that 'update' is a full replace, on every resource that supports it

### DIFF
--- a/.changeset/tidy-lions-smile.md
+++ b/.changeset/tidy-lions-smile.md
@@ -1,0 +1,5 @@
+---
+"google-tag-manager-mcp-core": patch
+---
+
+Document that `update` replaces the entire resource across all tools that support it (tag, trigger, client, container, environment, folder, Google tag config, transformation, container version, custom template, user permission, zone, workspace, account) — matching the warning `gtm_variable` already had. Callers, including AI agents, should always `get` the current object first and send back the complete thing with modifications applied, since any field left out is deleted.

--- a/packages/core/src/tools/accountActions.ts
+++ b/packages/core/src/tools/accountActions.ts
@@ -27,7 +27,7 @@ export const accountActions = (
         ),
       accountId: z.string().describe("The unique ID of the GTM Account."),
       config: PayloadSchema.optional().describe(
-        "Configuration for 'update' action. All fields correspond to the GTM Account resource.",
+        "Configuration for 'update' action. All fields correspond to the GTM Account resource. 'update' replaces the entire account — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
     },
     async ({ action, accountId, config }) => {

--- a/packages/core/src/tools/clientActions.ts
+++ b/packages/core/src/tools/clientActions.ts
@@ -50,7 +50,7 @@ export const clientActions = (
           "The unique ID of the GTM Client. Required for 'get', 'update', 'remove', and 'revert' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Client resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Client resource, except IDs. 'update' replaces the entire client — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/containerActions.ts
+++ b/packages/core/src/tools/containerActions.ts
@@ -69,7 +69,7 @@ export const containerActions = (
           "The destination ID linked to a GTM Container (e.g., AW-123456789). Required for the 'lookup' action.",
         ),
       createOrUpdateConfig: ContainerPayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Container resource.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Container resource. 'update' replaces the entire container — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/environmentActions.ts
+++ b/packages/core/src/tools/environmentActions.ts
@@ -50,7 +50,7 @@ export const environmentActions = (
           "The unique ID of the GTM Environment. Required for 'get', 'update', 'remove', and 'reauthorize' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Environment resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Environment resource, except IDs. 'update' replaces the entire environment — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/folderActions.ts
+++ b/packages/core/src/tools/folderActions.ts
@@ -59,7 +59,7 @@ export const folderActions = (
           "The unique ID of the GTM Folder. Required for 'get', 'update', 'remove', 'revert', 'entities', and 'moveEntitiesToFolder' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Folder resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM Folder resource, except IDs. 'update' replaces the entire folder — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/gtagConfigActions.ts
+++ b/packages/core/src/tools/gtagConfigActions.ts
@@ -56,7 +56,7 @@ export const gtagConfigActions = (
           "The unique ID of the Google tag config. Required for 'get', 'update', and 'remove' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the Google tag config resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the Google tag config resource, except IDs. 'update' replaces the entire Google tag config — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/tagActions.ts
+++ b/packages/core/src/tools/tagActions.ts
@@ -50,7 +50,7 @@ export const tagActions = (
           "The unique ID of the GTM tag. Required for 'get', 'update', 'remove', and 'revert' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM tag resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM tag resource, except IDs. 'update' replaces the entire tag — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/templateActions.ts
+++ b/packages/core/src/tools/templateActions.ts
@@ -56,7 +56,7 @@ export const templateActions = (
           "The unique ID of the GTM custom template. Required for 'get', 'update', 'remove', and 'revert' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM custom template resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM custom template resource, except IDs. 'update' replaces the entire custom template — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/transformationActions.ts
+++ b/packages/core/src/tools/transformationActions.ts
@@ -56,7 +56,7 @@ export const transformationActions = (
           "The unique ID of the GTM transformation. Required for 'get', 'update', 'remove', and 'revert' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM transformation resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM transformation resource, except IDs. 'update' replaces the entire transformation — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/triggerActions.ts
+++ b/packages/core/src/tools/triggerActions.ts
@@ -50,7 +50,7 @@ export const triggerActions = (
           "The unique ID of the GTM trigger. Required for 'get', 'update', 'remove', and 'revert' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM trigger resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM trigger resource, except IDs. 'update' replaces the entire trigger — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/userPermissionActions.ts
+++ b/packages/core/src/tools/userPermissionActions.ts
@@ -39,7 +39,7 @@ export const userPermissionActions = (
           "The unique ID of the user permission. Required for 'get', 'update', and 'remove' actions.",
         ),
       createOrUpdateConfig: UserPermissionSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM user permission resource.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM user permission resource. 'update' replaces the entire user permission — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       page: z
         .number()

--- a/packages/core/src/tools/versionActions.ts
+++ b/packages/core/src/tools/versionActions.ts
@@ -55,7 +55,7 @@ export const versionActions = (
           "The unique ID of the GTM container version. Required for 'get', 'publish', 'remove', 'setLatest', 'undelete', and 'update' actions.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM container version resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM container version resource, except IDs. 'update' replaces the entire container version — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/workspaceActions.ts
+++ b/packages/core/src/tools/workspaceActions.ts
@@ -83,7 +83,7 @@ export const workspaceActions = (
           "The unique ID of the GTM Workspace. Required for all actions except 'create' and 'list'.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM workspace resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM workspace resource, except IDs. 'update' replaces the entire workspace — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()

--- a/packages/core/src/tools/zoneActions.ts
+++ b/packages/core/src/tools/zoneActions.ts
@@ -51,7 +51,7 @@ export const zoneActions = (
           "The unique ID of the GTM Zone. Required for all actions except 'create' and 'list'.",
         ),
       createOrUpdateConfig: PayloadSchema.optional().describe(
-        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM zone resource, except IDs.",
+        "Configuration for 'create' and 'update' actions. All fields correspond to the GTM zone resource, except IDs. 'update' replaces the entire zone — any field omitted here is deleted. Always run 'get' first and send back the complete object with your modifications applied.",
       ),
       fingerprint: z
         .string()


### PR DESCRIPTION
## Summary

- `gtm_variable` already documents that `update` replaces the entire resource and tells the caller to `get` first (added in `7b433ac`, after a bug where partial updates silently dropped fields like `formatValue`/`parentFolderId`).
- Every other resource with a full-PUT `update` (tag, trigger, client, container, environment, folder, Google tag config, transformation, container version, custom template, user permission, zone, workspace, account) had no such warning, even though they send `requestBody: createOrUpdateConfig` directly the same way.
- Confirmed live (see #78's testing) that a name-only `gtm_tag update` genuinely 400s with a confusing Google error, because omitting `type`/`parameter` drops them from the full-replace body — this is expected API behavior, not a bug, but nothing told the calling agent that upfront.
- This extends the exact same warning sentence to all 14 remaining action files' `createOrUpdateConfig`/`config` descriptions. No logic changes.

## Test plan

- [x] `npm run build` / `npm run typecheck` pass (description-string-only change).
- [x] Changeset added (`google-tag-manager-mcp-core`, patch; `updateInternalDependencies: patch` in `.changeset/config.json` bumps the cli automatically).

Depends on #78 (based on that branch — merge #78 first).