### PR TITLE
Rework installation docs into a per-client Installation section

### DIFF
--- a/.changeset/yellow-bananas-cry.md
+++ b/.changeset/yellow-bananas-cry.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs only: reworked the root README's installation instructions into a per-client Installation section, and added credential examples for every method in `packages/cli/README.md`. No package code changed, so no version bump needed.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,32 @@
 
 An interface to the Google Tag Manager API over MCP, in two flavours: a hosted server with Google OAuth built in, and a local CLI that runs on your own credentials.
 
+## Table of Contents
+
+- [MCP Server for Google Tag Manager](#mcp-server-for-google-tag-manager)
+  - [Table of Contents](#table-of-contents)
+  - [Repository layout](#repository-layout)
+  - [Installation](#installation)
+    - [Claude Desktop](#claude-desktop)
+    - [Claude Code](#claude-code)
+    - [VS Code](#vs-code)
+    - [GitHub Copilot](#github-copilot)
+    - [Copilot CLI](#copilot-cli)
+    - [Cursor](#cursor)
+    - [Antigravity](#antigravity)
+    - [ChatGPT](#chatgpt)
+    - [Other MCP clients](#other-mcp-clients)
+    - [Troubleshooting](#troubleshooting)
+  - [Test your changes locally](#test-your-changes-locally)
+    - [Changes to `packages/core` or `packages/cli`](#changes-to-packagescore-or-packagescli)
+    - [Changes to `apps/worker`](#changes-to-appsworker)
+      - [1. Set up a Google Cloud OAuth client](#1-set-up-a-google-cloud-oauth-client)
+      - [2. Configure local environment variables](#2-configure-local-environment-variables)
+      - [3. Start the server](#3-start-the-server)
+      - [4. Point your MCP client at the local server](#4-point-your-mcp-client-at-the-local-server)
+  - [Releasing](#releasing)
+  - [Development](#development)
+
 ## Repository layout
 
 npm workspace with one app and two published packages:
@@ -15,11 +41,28 @@ npm workspace with one app and two published packages:
 
 Tools reach Google through a `GtmAuthProvider` (`getAccessToken(): Promise<string>`) rather than through any particular session, which is what lets the same tool set back both servers — and a private one with your own auth. See the [core package README](packages/core/README.md).
 
-## Use the hosted server
+## Installation
+
+This server comes in two flavours: Hosted server and Local CLI. Both give you the same 18 GTM tools; the difference is who handles Google auth.
+
+| | Hosted server | Local CLI |
+| --- | --- | --- |
+| Auth | Google OAuth in your browser, handled for you | You supply a service account key, refresh token, or access token |
+| Data | Passes through `gtm-mcp.stape.ai` | Only ever leaves your machine |
+| Setup | None | Set one environment variable |
+
+If you're a contributor testing an unreleased change rather than just using the tools, skip everything below and see [Test your changes locally](#test-your-changes-locally) instead.
+
+Pick your client below. The hosted server needs the [`mcp-remote`](https://github.com/geelen/mcp-remote#readme) bridge on clients whose MCP support doesn't complete Google's OAuth flow natively; where a client does that itself, it connects straight to `https://gtm-mcp.stape.ai/mcp`.
+
+### Claude Desktop
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
 
 Open Claude Desktop and navigate to Settings -> Developer -> Edit Config. This opens the configuration file that controls which MCP servers Claude can access.
 
-Replace the content with the following configuration. Once you restart Claude Desktop, a browser window will open showing your OAuth login page. Complete the authentication flow to grant Claude access to your MCP server. After you grant access, the tools will become available for you to use.
+**Hosted server** — restart Claude Desktop after saving; a browser window opens for the Google OAuth flow. Complete it to grant Claude access:
 
 ```json
 {
@@ -36,9 +79,7 @@ Replace the content with the following configuration. Once you restart Claude De
 }
 ```
 
-## Or run it locally
-
-No OAuth flow and no data through anyone else's server — you supply a service account key or a refresh token:
+**Local CLI** — no OAuth flow, no data through anyone else's server, you supply a service account key or a refresh token:
 
 ```json
 {
@@ -54,7 +95,256 @@ No OAuth flow and no data through anyone else's server — you supply a service 
 }
 ```
 
-See the [CLI README](packages/cli/README.md) for the credential options.
+See the [CLI README](packages/cli/README.md) for every credential option.
+
+</details>
+
+### Claude Code
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+Claude Code speaks HTTP directly, including the OAuth handshake, so the hosted server needs no bridge.
+
+**Hosted server**:
+
+```bash
+claude mcp add --transport http gtm-mcp-server https://gtm-mcp.stape.ai/mcp
+```
+
+A browser window opens for the Google OAuth flow the first time a tool is used. Run `/mcp` inside Claude Code to confirm it connected.
+
+**Local CLI**:
+
+```bash
+claude mcp add gtm-mcp-server -e GOOGLE_SERVICE_ACCOUNT_KEY='{"type":"service_account", ... }' -- npx -y google-tag-manager-mcp-server
+```
+
+Both write into `.mcp.json` / your Claude Code MCP config.
+
+</details>
+
+### VS Code
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+VS Code's MCP client supports HTTP servers and their OAuth flow natively, no `mcp-remote` needed. Add this to `.vscode/mcp.json`:
+
+**Hosted server**:
+
+```json
+{
+  "servers": {
+    "gtm-mcp-server": {
+      "type": "http",
+      "url": "https://gtm-mcp.stape.ai/mcp"
+    }
+  }
+}
+```
+
+**Local CLI**:
+
+```json
+{
+  "servers": {
+    "gtm-mcp-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "google-tag-manager-mcp-server"],
+      "env": {
+        "GOOGLE_SERVICE_ACCOUNT_KEY": "{\"type\":\"service_account\", ... }"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+### GitHub Copilot
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+GitHub Copilot Chat in VS Code uses VS Code's own MCP client, so it reads the same `.vscode/mcp.json` file — see [VS Code](#vs-code) above. No separate configuration is needed.
+
+</details>
+
+### Copilot CLI
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+Copilot CLI also completes OAuth natively for remote HTTP servers. Add this to `~/.copilot/mcp-config.json`:
+
+**Hosted server**:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "type": "http",
+      "url": "https://gtm-mcp.stape.ai/mcp"
+    }
+  }
+}
+```
+
+**Local CLI**:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "google-tag-manager-mcp-server"],
+      "env": {
+        "GOOGLE_SERVICE_ACCOUNT_KEY": "{\"type\":\"service_account\", ... }"
+      }
+    }
+  }
+}
+```
+
+See [GitHub's docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers) for the equivalent `copilot mcp add` subcommand.
+
+</details>
+
+### Cursor
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+Cursor speaks HTTP directly too, no `mcp-remote` needed. Add this to `.cursor/mcp.json` (project-level) or `~/.cursor/mcp.json` (global — Settings → MCP → Add new global MCP server):
+
+**Hosted server**:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "url": "https://gtm-mcp.stape.ai/mcp"
+    }
+  }
+}
+```
+
+A browser window opens for the Google OAuth flow the first time a tool is used.
+
+**Local CLI**:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "google-tag-manager-mcp-server"],
+      "env": {
+        "GOOGLE_SERVICE_ACCOUNT_KEY": "{\"type\":\"service_account\", ... }"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+### Antigravity
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+Antigravity's own OAuth support for remote HTTP servers doesn't reliably reach a token to the server yet ([antigravity-cli#25](https://github.com/google-antigravity/antigravity-cli/issues/25)), so use `mcp-remote` for the hosted server here too, the same way Claude Desktop does. Add this to `~/.gemini/config/mcp_config.json` (global) or `.agents/mcp_config.json` (workspace-local) — accessible from the editor's agent panel via **… → MCP Servers → Manage MCP Servers → View raw config**:
+
+**Hosted server**:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://gtm-mcp.stape.ai/mcp"
+      ]
+    }
+  }
+}
+```
+
+**Local CLI**:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "google-tag-manager-mcp-server"],
+      "env": {
+        "GOOGLE_SERVICE_ACCOUNT_KEY": "{\"type\":\"service_account\", ... }"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+### ChatGPT
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+1. In ChatGPT, enable Developer mode: Settings → Apps & Connectors → Advanced settings → Developer mode.
+2. Go to Settings → Connectors → Create, and set the server URL to `https://gtm-mcp.stape.ai/mcp`.
+3. Set Authentication to **OAuth** and complete the Google login in the browser window that opens.
+
+ChatGPT only reaches servers over the public internet, it can't spawn a local process — so there's no Local CLI option here, only the hosted server.
+
+</details>
+
+### Other MCP clients
+
+<details>
+<summary>⬇️ Click to expand ⬇️</summary>
+
+Any other MCP-compatible client that expects a stdio-style `command`/`args` config can use the same `mcp-remote` block for the hosted server:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://gtm-mcp.stape.ai/mcp"
+      ]
+    }
+  }
+}
+```
+
+Or the local CLI directly, with your credentials:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "google-tag-manager-mcp-server"],
+      "env": {
+        "GOOGLE_SERVICE_ACCOUNT_KEY": "{\"type\":\"service_account\", ... }"
+      }
+    }
+  }
+}
+```
+
+</details>
 
 ### Troubleshooting
 
@@ -67,19 +357,60 @@ To avoid this issue:
 
 **Clearing MCP Cache**
 
-[mcp-remote](https://github.com/geelen/mcp-remote#readme) stores all the credential information inside `~/.mcp-auth` (or wherever your `MCP_REMOTE_CONFIG_DIR` points to). If you're having persistent issues, try running:
+If you're connecting through `mcp-remote` (Claude Desktop, Antigravity), it stores all the credential information inside `~/.mcp-auth` (or wherever your `MCP_REMOTE_CONFIG_DIR` points to). If you're having persistent issues, try running:
 ```bash
 rm -rf ~/.mcp-auth
 ```
 Then, restart your MCP client.
 
-## Running the Worker locally
+## Test your changes locally
 
-You can run the hosted server on your own machine against your own Google Cloud OAuth
-credentials instead of `gtm-mcp.stape.ai`. This is useful for testing
-changes before they're deployed.
+Which workflow you need depends on what you changed. Most changes are in the first
+category — reach for the second only if you're touching the Worker itself.
 
-### 1. Set up a Google Cloud OAuth client
+### Changes to `packages/core` or `packages/cli`
+
+This is the tool logic itself (schemas, GTM API calls, error handling) — almost
+everything you'd fix or add lives here. You don't need a Google Cloud OAuth client
+or any Worker setup: build from source and run the CLI directly with credentials
+you already have.
+
+```bash
+git clone https://github.com/stape-io/google-tag-manager-mcp-server
+cd google-tag-manager-mcp-server
+gh pr checkout <PR number>   # or: git checkout <your-branch>
+npm install
+npm run build
+```
+
+Point your MCP client at the local build instead of `npx` — same credential
+options as the [Claude Desktop](#claude-desktop) Local CLI example above, an access
+token from the [OAuth Playground](https://developers.google.com/oauthplayground) is
+the fastest way to test a single change:
+
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-local": {
+      "command": "node",
+      "args": ["/absolute/path/to/google-tag-manager-mcp-server/packages/cli/dist/index.js"],
+      "env": {
+        "GOOGLE_ACCESS_TOKEN": "..."
+      }
+    }
+  }
+}
+```
+
+See the [CLI README](packages/cli/README.md) for every credential option.
+
+### Changes to `apps/worker`
+
+Only needed for the hosted server's own code: the OAuth flow, routing, session
+handling, the approval and status pages. This runs that code on your own machine
+against your own Google Cloud OAuth credentials instead of `gtm-mcp.stape.ai`.
+
+#### 1. Set up a Google Cloud OAuth client
 
 1. In the [Google Cloud Console](https://console.cloud.google.com/), create or select a project, then enable the **Tag Manager API**.
 2. Go to **APIs & Services > OAuth consent screen** and configure it (External is fine). While the app is in **Testing** publishing status, only accounts listed as test users can log in.
@@ -88,7 +419,7 @@ changes before they're deployed.
 5. Under **Authorized redirect URIs**, add `http://localhost:8788/callback`. (You can leave **Authorized JavaScript origins** empty — this flow is server-side only, no browser JS calls Google directly.)
 6. Save, then copy the generated **Client ID** and **Client secret**.
 
-### 2. Configure local environment variables
+#### 2. Configure local environment variables
 
 Copy the example file and fill in the values from the previous step:
 
@@ -106,7 +437,7 @@ HOSTED_DOMAIN=""
 
 `.dev.vars` is git-ignored — it's only used locally and never committed.
 
-### 3. Start the server
+#### 3. Start the server
 
 ```bash
 npm install
@@ -116,9 +447,9 @@ npm run dev
 
 `npm run build` compiles the core package the Worker bundles against; `npm run dev` starts the Worker on `http://localhost:8788`.
 
-### 4. Point your MCP client at the local server
+#### 4. Point your MCP client at the local server
 
-Same as the [Claude Desktop config above](#use-the-hosted-server), but pointing at `localhost` instead of the hosted URL:
+Same as the [Hosted server config above](#claude-desktop), but pointing at `localhost` instead of the hosted URL:
 
 ```json
 {
@@ -135,7 +466,7 @@ Restart Claude Desktop. A browser window will open for the Google OAuth flow; lo
 account you added as a test user in step 1.
 
 **Note:** if you've previously connected to the hosted server (or switch back and forth between
-local and hosted), clear mcp-remote's cache first (see "Clearing MCP Cache" above)
+local and hosted), clear mcp-remote's cache first (see [Troubleshooting](#troubleshooting) above)
 and fully restart your MCP client, otherwise it may reuse a stale/cached connection.
 
 ## Releasing

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,9 @@
 
 A local MCP server for the Google Tag Manager API. It runs on your machine and authenticates with credentials you provide, so no data passes through anyone else's server.
 
-If you would rather not manage credentials, use the hosted server instead — it handles Google OAuth for you, see the [repository README](https://github.com/stape-io/google-tag-manager-mcp-server#readme).
+If you would rather not manage credentials, use the hosted server instead — it handles Google OAuth for you, see the [repository README](../../README.md).
+
+Testing an unreleased fix or contributing to this repo? Don't use `npx` here — see [Test your changes locally](../../README.md#test-your-changes-locally) in the repository README instead, it builds from source so your changes are actually included.
 
 ## Usage
 
@@ -32,26 +34,42 @@ Set one of these in the server's environment.
 2. Create a JSON key for it.
 3. In GTM, add the service account's email (`...@....iam.gserviceaccount.com`) as a user on each account or container it should manage.
 
-```
-GOOGLE_SERVICE_ACCOUNT_KEY={"type":"service_account", ... }
-```
-
-The key can also be split into `GOOGLE_CLIENT_EMAIL` + `GOOGLE_PRIVATE_KEY`. For Google Workspace domain-wide delegation, add `GOOGLE_IMPERSONATED_USER`.
+See it plugged into an MCP client config in [Usage](#usage) above. The key can also be split into `GOOGLE_CLIENT_EMAIL` + `GOOGLE_PRIVATE_KEY`. For Google Workspace domain-wide delegation, add `GOOGLE_IMPERSONATED_USER`.
 
 ### OAuth refresh token
 
 Acts as one specific Google account — useful when GTM access cannot be shared with a service account.
 
-```
-GOOGLE_CLIENT_ID=...
-GOOGLE_CLIENT_SECRET=...
-GOOGLE_REFRESH_TOKEN=...
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "google-tag-manager-mcp-server"],
+      "env": {
+        "GOOGLE_CLIENT_ID": "...",
+        "GOOGLE_CLIENT_SECRET": "...",
+        "GOOGLE_REFRESH_TOKEN": "..."
+      }
+    }
+  }
+}
 ```
 
 ### Access token
 
-```
-GOOGLE_ACCESS_TOKEN=...
+```json
+{
+  "mcpServers": {
+    "gtm-mcp-server": {
+      "command": "npx",
+      "args": ["-y", "google-tag-manager-mcp-server"],
+      "env": {
+        "GOOGLE_ACCESS_TOKEN": "..."
+      }
+    }
+  }
+}
 ```
 
 Expires within the hour and is not refreshed — debugging only.


### PR DESCRIPTION
## Summary

- The root README only documented connecting Claude Desktop, and separately conflated "run it locally" (the CLI package, no OAuth setup needed) with "run the Worker locally" (contributor-only, needs a GCP OAuth client) — confusing for first-time readers.
- Replaces the old two-section layout with a single **Installation** section, one subsection per client: Claude Desktop, Claude Code, VS Code, GitHub Copilot, Copilot CLI, Cursor, Antigravity, ChatGPT, Other MCP clients (matching [stape-mcp-server's Installation section](https://github.com/stape-io/stape-mcp-server/blob/feat/add-almost-all-stape-api-features/README.md#installation), which the client list mirrors in full).
- Each client section is collapsed behind a `<details>`/`<summary>⬇️ Click to expand ⬇️</summary>` block to keep the page scannable.
- Hosted-server config per client uses native HTTP+OAuth where it actually works, and falls back to `mcp-remote` where it doesn't:
  - Native: Claude Code (verified directly in this session), VS Code (GA since v1.102, RFC9728+DCR), Cursor (OAuth since v1.0), Copilot CLI (`github/copilot-cli#33` closed 2026-02-05).
  - `mcp-remote` fallback: Claude Desktop (its config-file path is stdio-only), Antigravity (open bug, `antigravity-cli#25`: OAuth bearer token isn't attached to requests), and the generic "Other MCP clients" catch-all.
  - ChatGPT is OAuth-only and hosted-only (it can't spawn a local process, so there's no Local CLI option there).
- Added a Table of Contents.
- `packages/cli/README.md`: added a config example for each of the three credential methods (previously only the first was shown), and switched the two links to the root README from full GitHub URLs to relative paths.

## Test plan

- [x] Verified all 17 JSON code blocks across both READMEs parse as valid JSON.
- [x] Verified every internal anchor link (Table of Contents + cross-references) resolves to an actual header.
- [x] Verified `<details>`/`</details>` tags are balanced (9 opens, 9 closes) and each pair wraps exactly one client section, keeping the `###` header itself outside/above the collapsed block so anchors and the ToC still work.
- Docs only, no code changes — no build/typecheck needed.