### PR TITLE
docs: fix blog URL for GTM MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Both `@modelcontextprotocol/sdk` and `agents` are pinned to exact versions in `a
 
 ## Useful resources
 
-- [Step-by-step guide: MCP Server for Google Ads](https://stape.io/blog/mcp-server-for-google-ads)
+- [Step-by-step guide: MCP Server for Google Tag Manager](https://stape.io/blog/mcp-server-for-google-tag-manager)
 
 ## Open Source
 


### PR DESCRIPTION
## Summary
- PR #83 merged before the URL fix commit was pushed, so main still links to the Google Ads blog post instead of the GTM one.
- Corrects the "Useful resources" link to https://stape.io/blog/mcp-server-for-google-tag-manager.

## Test plan
- [x] Link points to the GTM blog post